### PR TITLE
Use custom version of gazebo_ros_pkgs

### DIFF
--- a/ariac-competitor/ariac-competitor/run_team_system_with_delay.bash
+++ b/ariac-competitor/ariac-competitor/run_team_system_with_delay.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo "Waiting for ROS master"
-. /opt/ros/indigo/setup.bash
+. /opt/ros/*/setup.bash
 until rostopic list ; do sleep 1; done
 
 # Wait for the ARIAC server to come up

--- a/ariac-server/ariac-server/Dockerfile
+++ b/ariac-server/ariac-server/Dockerfile
@@ -77,7 +77,7 @@ RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO_BUILD_TIME}/setup.bash && \
                   catkin_init_workspace"
 RUN git clone \
       https://github.com/ros-simulation/gazebo_ros_pkgs /tmp/ros_ws/src/gazebo_ros_pkgs \
-      -b ${ROS_DISTRO_BUILD_TIME}-devel
+      -b ariac-network-${ROS_DISTRO_BUILD_TIME}
 RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO_BUILD_TIME}/setup.bash && \
                   cd /tmp/ros_ws/ && \
                   catkin_make -DCMAKE_INSTALL_PREFIX=/opt/ros/${ROS_DISTRO_BUILD_TIME} -j2 install "

--- a/ariac-server/ariac-server/Dockerfile
+++ b/ariac-server/ariac-server/Dockerfile
@@ -18,6 +18,69 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Need to install an specific version of gazebo_ros_pkgs
+# 1. Install dependencies
+RUN apt-get update && apt-get install -y \
+        libgazebo7-dev                                       \
+	ros-${ROS_DISTRO_BUILD_TIME}-ros                     \
+	ros-${ROS_DISTRO_BUILD_TIME}-catkin                  \
+	ros-${ROS_DISTRO_BUILD_TIME}-pluginlib               \
+	ros-${ROS_DISTRO_BUILD_TIME}-roscpp                  \
+	ros-${ROS_DISTRO_BUILD_TIME}-angles                  \
+	ros-${ROS_DISTRO_BUILD_TIME}-camera-info-manager     \
+	ros-${ROS_DISTRO_BUILD_TIME}-cmake-modules           \
+	ros-${ROS_DISTRO_BUILD_TIME}-controller-manager      \
+	ros-${ROS_DISTRO_BUILD_TIME}-control-toolbox         \
+	ros-${ROS_DISTRO_BUILD_TIME}-tf                      \
+	ros-${ROS_DISTRO_BUILD_TIME}-cv-bridge               \
+	ros-${ROS_DISTRO_BUILD_TIME}-diagnostic-updater      \
+	ros-${ROS_DISTRO_BUILD_TIME}-dynamic-reconfigure     \
+	ros-${ROS_DISTRO_BUILD_TIME}-geometry-msgs           \
+	ros-${ROS_DISTRO_BUILD_TIME}-image-transport         \
+	ros-${ROS_DISTRO_BUILD_TIME}-joint-limits-interface  \
+	ros-${ROS_DISTRO_BUILD_TIME}-message-generation      \
+	ros-${ROS_DISTRO_BUILD_TIME}-nav-msgs                \
+	ros-${ROS_DISTRO_BUILD_TIME}-nodelet                 \
+	ros-${ROS_DISTRO_BUILD_TIME}-pcl-conversions         \
+	ros-${ROS_DISTRO_BUILD_TIME}-polled-camera           \
+	ros-${ROS_DISTRO_BUILD_TIME}-rosconsole              \
+	ros-${ROS_DISTRO_BUILD_TIME}-rosgraph-msgs           \
+	ros-${ROS_DISTRO_BUILD_TIME}-sensor-msgs             \
+	ros-${ROS_DISTRO_BUILD_TIME}-std-srvs                \
+	ros-${ROS_DISTRO_BUILD_TIME}-tf                      \
+	ros-${ROS_DISTRO_BUILD_TIME}-tf2-ros                 \
+	ros-${ROS_DISTRO_BUILD_TIME}-trajectory-msgs         \
+	ros-${ROS_DISTRO_BUILD_TIME}-transmission-interface  \
+	ros-${ROS_DISTRO_BUILD_TIME}-urdf                    \
+	ros-${ROS_DISTRO_BUILD_TIME}-xacro                   \
+	ros-${ROS_DISTRO_BUILD_TIME}-ros-base                \
+	ros-${ROS_DISTRO_BUILD_TIME}-pcl-ros                 \
+	&& apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+RUN if [ "${ROS_DISTRO_BUILD_TIME}" = "indigo" ]; then \
+      apt-get install -y ros-${ROS_DISTRO_BUILD_TIME}-driver-base; \
+    fi \
+	&& apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+# 2. Remove official packages
+RUN if [ "${ROS_DISTRO_BUILD_TIME}" = "indigo" ]; then \
+       export GZ_VERSION=7; \
+    fi && \
+    dpkg -r --force-depends ros-${ROS_DISTRO_BUILD_TIME}-gazebo${GZ_VERSION}-ros-pkgs \
+                            ros-${ROS_DISTRO_BUILD_TIME}-gazebo${GZ_VERSION}-ros \
+                            ros-${ROS_DISTRO_BUILD_TIME}-gazebo${GZ_VERSION}-plugins \
+                            ros-${ROS_DISTRO_BUILD_TIME}-gazebo${GZ_VERSION}-msgs \
+                            ros-${ROS_DISTRO_BUILD_TIME}-gazebo${GZ_VERSION}-ros-control
+RUN mkdir -p /tmp/ros_ws/src
+RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO_BUILD_TIME}/setup.bash && \
+                  cd /tmp/ros_ws/src && \
+                  catkin_init_workspace"
+RUN git clone \
+      https://github.com/ros-simulation/gazebo_ros_pkgs /tmp/ros_ws/src/gazebo_ros_pkgs \
+      -b ${ROS_DISTRO_BUILD_TIME}-devel
+RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO_BUILD_TIME}/setup.bash && \
+                  cd /tmp/ros_ws/ && \
+                  catkin_make -DCMAKE_INSTALL_PREFIX=/opt/ros/${ROS_DISTRO_BUILD_TIME} -j2 install "
 # setup entrypoint
 COPY ./ariac_entrypoint.sh /
 COPY ./run_ariac_task.sh /


### PR DESCRIPTION
The changes install and build gazebo_ros_pkgs in the ariac-server Dockerfile.

The goal is to be able to replace the package version by a custom branch. In this PR the custom branch is just the default branch for each distro (`kinetic-devel` or `indigo-devel`). After installing the ariac package what I'm doing is using dpkg to remove the gazebo_ros_pkgs debs without removing the software that depends on them (ariac) and build and install a copy of gazebo_ros_pkgs from source into `/opt/ros/$ROS_DISTRO`.