### PR TITLE
Meta-batch mode that runs all teams' systems for all trials

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,9 @@ Type `exit` to stop the container.
 Once your team's system has been successfully installed in the competitor container, if you are having difficulties *running* your team's system, you can open a terminal in the container that has your system installed with:
 
 ```
-docker run -it --rm --name ariac-competitor-system ariac-competitor
+docker run -it --rm --name ariac-competitor-system ariac-competitor-<your_team_name>
+# e.g. for example_team:
+# docker run -it --rm --name ariac-competitor-system ariac-competitor-example_team
 ```
 
 Inside the container you can look around with, for example:

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ To prepare the ARIAC competition system (but not run it), call:
 
 This will build a Docker "image" of the competition server, ready to be launched as a container later.
 
+This will take a while to build, but you will not have to re-build it often.
+
 By default, ROS Indigo on Ubuntu Trusty will be used.
 You can call `./prepare_ariac_system.bash kinetic` to build with ROS Kinetic on Ubuntu Xenial.
 
@@ -67,7 +69,7 @@ To prepare your team's system (but not run it), call:
 This will build a Docker "image" of your team's system, ready to be launched with the ARIAC competition server.
 
 By default, ROS Indigo on Ubuntu Trusty will be used.
-You can call `./prepare_team_system.bash <your_team_name> kinetic` to build with ROS Kinetic on Ubuntu Xenial.
+You can add `ros_distro.txt`, with contents of `kinetic` to your team's configuration directory if you want your system to be built with ROS Kinetic on Ubuntu Xenial.
 
 ## Running a single trial
 
@@ -149,7 +151,7 @@ This will run each of the trials sequentially automatically.
 This is the invocation that will be used to test submissions for the Finals: your system will not be provided with any information about the trial number or the conditions of the trial.
 If your system performs correctly with this invocation, regardless of the set of configuration files in the `comp_configs` directory, you're ready for the competition.
 
-## Troubleshooting
+## Development tips
 
 ### Keeping the competition setup software up to date
 
@@ -164,6 +166,12 @@ If during your development you need to kill the ARIAC server/competitor containe
 ```
 
 This will kill and remove all ARIAC containers.
+
+### Utilizing the Docker cache to when re-building the competitor system
+
+By default, runnng `./build_team_system.bash <your_team_name>` will re-build the image from scratch.
+During development you may find it useful to call `./build_team_system.bash <your_team_name> --use-cache` to re-use already-built image in the Docker cache if appropriate.
+However, new versions of packages may have been released since the images in the cache were built, and this will not trigger images to be re-built. Therefore you must not use this option when testing your finalized system for submission.
 
 ### Investigating build issues
 

--- a/ariac-competitor/ariac-competitor/Dockerfile
+++ b/ariac-competitor/ariac-competitor/Dockerfile
@@ -2,10 +2,11 @@ FROM ariac-competitor-clean:latest
 
 COPY ./build_team_system.bash /
 RUN chmod 755 /build_team_system.bash
+RUN /build_team_system.bash
+
 COPY ./run_team_system.bash /
 RUN chmod 755 /run_team_system.bash
 COPY ./run_team_system_with_delay.bash /
 RUN chmod 755 /run_team_system_with_delay.bash
 
-RUN /build_team_system.bash
 ENTRYPOINT ["/bin/bash"]

--- a/ariac-competitor/ariac-competitor/run_team_system_with_delay.bash
+++ b/ariac-competitor/ariac-competitor/run_team_system_with_delay.bash
@@ -8,5 +8,7 @@ until rostopic list ; do sleep 1; done
 sleep 10
 
 # Run the team's system
-echo "Running team system"
+echo "Running team's system"
 /run_team_system.bash
+
+echo "Team's system finished running"

--- a/ariac-competitor/build_competitor_image.bash
+++ b/ariac-competitor/build_competitor_image.bash
@@ -45,7 +45,7 @@ cp ${TEAM_CONFIG_DIR}/build_team_system.bash ${DIR}/ariac-competitor/build_team_
 cp ${TEAM_CONFIG_DIR}/run_team_system.bash ${DIR}/ariac-competitor/run_team_system.bash
 
 docker build ${DOCKER_ARGS} -t ariac-competitor-clean:latest ${DIR}/ariac-competitor-clean
-docker build ${DOCKER_ARGS} -t ariac-competitor:latest ${DIR}/ariac-competitor
+docker build ${DOCKER_ARGS} -t ariac-competitor-${TEAM_NAME}:latest ${DIR}/ariac-competitor
 
 echo "Removing temporary team scripts"
 rm ${DIR}/ariac-competitor/build_team_system.bash

--- a/ariac-competitor/build_competitor_image.bash
+++ b/ariac-competitor/build_competitor_image.bash
@@ -2,14 +2,11 @@
 
 set -x
 
-DOCKER_ARGS=""
-# Uncoment this line to rebuild without cache
-# TODO: expose this as an argument
-#DOCKER_ARGS="--no-cache"
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 TEAM_NAME=$1
+DOCKER_ARGS=$2
+
 TEAM_CONFIG_DIR=${DIR}/../team_configs/${TEAM_NAME}
 
 ROS_DISTRO_FILE=${TEAM_CONFIG_DIR}/ros_distro.txt

--- a/ariac-competitor/run_competitor_container.bash
+++ b/ariac-competitor/run_competitor_container.bash
@@ -28,7 +28,8 @@ SERVER_IP="172.18.0.22"
 
 echo -e "${GREEN}Starting docker container named '${CONTAINER}' with IP ${IP}...${NOCOLOR}"
 
-docker run --rm --name ${CONTAINER} \
+# Keep the container around afterwards (no --rm) in case we need to copy files.
+docker run --name ${CONTAINER} \
   -e ROS_IP=${IP} \
   -e ROS_MASTER_URI=http://${SERVER_IP}:11311 \
   --ip ${IP} \

--- a/ariac-competitor/run_competitor_container.bash
+++ b/ariac-competitor/run_competitor_container.bash
@@ -16,10 +16,11 @@ GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
 NOCOLOR='\033[0m'
 
-CONTAINER="ariac-competitor-system"
-IMAGE_NAME="ariac-competitor"
+IMAGE_NAME=$1
+COMMAND=$2
+
+CONTAINER="${IMAGE_NAME}-system"
 DOCKER_EXTRA_ARGS=""
-COMMAND=$1
 
 NETWORK="ariac-network"
 IP="172.18.0.20"

--- a/ariac-server/ariac-server/run_ariac_task.sh
+++ b/ariac-server/ariac-server/run_ariac_task.sh
@@ -47,5 +47,8 @@ cp --recursive --dereference ~/.ariac/log/* $DST_FOLDER
 # Copy ROS log files.
 mkdir -p $DST_FOLDER/ros
 cp --recursive --dereference ~/.ros/log/latest/* $DST_FOLDER/ros
+# Copy ARIAC generated files.
+mkdir -p $DST_FOLDER/generated
+cp --recursive --dereference /tmp/ariac/* $DST_FOLDER/generated
 
 echo -e "${GREEN}OK${NOCOLOR}"

--- a/ariac-server/ariac-server/run_ariac_task.sh
+++ b/ariac-server/ariac-server/run_ariac_task.sh
@@ -41,8 +41,11 @@ ARIAC_EXIT_ON_COMPLETION=1 rosrun osrf_gear gear.py --no-gui -v -f $1 $2
 
 echo -e "${GREEN}OK${NOCOLOR}"
 
-# Copy log files.
+# Copy ARIAC log files.
 echo -n "Copying logs into [$DST_FOLDER]..."
 cp --recursive --dereference ~/.ariac/log/* $DST_FOLDER
+# Copy ROS log files.
+mkdir -p $DST_FOLDER/ros
+cp --recursive --dereference ~/.ros/log/latest/* $DST_FOLDER/ros
 
 echo -e "${GREEN}OK${NOCOLOR}"

--- a/prepare_team_system.bash
+++ b/prepare_team_system.bash
@@ -4,14 +4,35 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 TEAM_NAME=${1}
 
+YELLOW='\033[0;33m'
+NOCOLOR='\033[0m'
+
 if [[ $# -lt 1 ]]; then
-  echo "$0 <team-image-dir-name>"
+  echo "$0 <team-image-dir-name> [--use-cache]"
   exit 1
 fi
 
 if [[ ! -d team_configs/${TEAM_NAME} ]]; then
   echo "Can not find team directory in 'team_configs' directory: ${TEAM_NAME}"
   exit 1
+fi
+
+# By default, don't use the Docker cache so that team's systems are always using
+# the most recent packages.
+EXTRA_DOCKER_ARGS="--no-cache"
+
+if [[ $# -gt 1 ]]; then
+  case ${2} in
+    "--use-cache")
+      EXTRA_DOCKER_ARGS=""
+      echo -e "${YELLOW}Wrn: Docker cache will be used.
+       Beware that the image may be using out of date packages!${NOCOLOR}"
+      sleep 2
+      ;;
+    *)
+      echo "Unsupported argument: ${2}"
+      exit 1
+  esac
 fi
 
 echo "Preparing the team system setup for team ${TEAM_NAME}"

--- a/run_all_teams.bash
+++ b/run_all_teams.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+COMP_CONFIGS_DIR=${DIR}/comp_configs/
+
+LIST_OF_TEAMS="example_team example_team2"
+
+for TEAM_NAME in ${LIST_OF_TEAMS}; do
+  echo "Running team: ${TEAM_NAME}"
+  ./run_all_trials.bash "${TEAM_NAME}"
+done

--- a/run_all_teams.bash
+++ b/run_all_teams.bash
@@ -9,6 +9,5 @@ COMP_CONFIGS_DIR=${DIR}/comp_configs/
 LIST_OF_TEAMS="example_team example_team2"
 
 for TEAM_NAME in ${LIST_OF_TEAMS}; do
-  echo "Running team: ${TEAM_NAME}"
   ./run_all_trials.bash "${TEAM_NAME}"
 done

--- a/run_all_trials.bash
+++ b/run_all_trials.bash
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 
-set -e
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Constants.
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NOCOLOR='\033[0m'
 
 TEAM_NAME=$1
 
@@ -22,9 +26,18 @@ get_list_of_trials()
   echo $all_names
 }
 
+echo -e "
+${GREEN}Running all trials for team: ${TEAM_NAME}${NOCOLOR}"
+
 for TRIAL_NAME in $(get_list_of_trials); do
-  echo "Running trial: ${TRIAL_NAME}"
+  echo "Running trial: ${TRIAL_NAME}..."
   CONSOLE_OUTPUT_DIR=logs/${TEAM_NAME}/${TRIAL_NAME}
   mkdir -p ${CONSOLE_OUTPUT_DIR}
   ./run_trial.bash "${TEAM_NAME}" "${TRIAL_NAME}" > ${CONSOLE_OUTPUT_DIR}/output.txt 2>&1
+  exit_status=$?
+  if [ $exit_status -eq 0 ]; then
+    echo -e "${GREEN}OK.${NOCOLOR}"
+  else
+    echo -e "${RED}TRIAL FAILED: ${TEAM_NAME}/${TRIAL_NAME}${NOCOLOR}" >&2
+  fi
 done

--- a/run_all_trials.bash
+++ b/run_all_trials.bash
@@ -24,5 +24,7 @@ get_list_of_trials()
 
 for TRIAL_NAME in $(get_list_of_trials); do
   echo "Running trial: ${TRIAL_NAME}"
-  ./run_trial.bash "${TEAM_NAME}" "${TRIAL_NAME}"
+  CONSOLE_OUTPUT_DIR=logs/${TEAM_NAME}/${TRIAL_NAME}
+  mkdir -p ${CONSOLE_OUTPUT_DIR}
+  ./run_trial.bash "${TEAM_NAME}" "${TRIAL_NAME}" > ${CONSOLE_OUTPUT_DIR}/output.txt 2>&1
 done

--- a/run_trial.bash
+++ b/run_trial.bash
@@ -5,7 +5,12 @@ set -e
 TEAM_NAME=$1
 TRIAL_NAME=$2
 
-#TODO: generate unique container names based on input arguments
+# Constants.
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NOCOLOR='\033[0m'
+
 CONTAINER_NAME=ariac-server-system
 
 HOST_LOG_DIR=`pwd`/logs/${TEAM_NAME}/${TRIAL_NAME}
@@ -46,5 +51,10 @@ COMPETITOR_IMAGE_NAME="ariac-competitor-${TEAM_NAME}"
   -v ${HOST_LOG_DIR}:${LOG_DIR} \
   -e ARIAC_EXIT_ON_COMPLETION=1" \
   "/run_ariac_task.sh /ariac/comp_configs/${TRIAL_NAME}.yaml /team_config/team_config.yaml ${LOG_DIR}"
+
+# Copy the ROS log files from the competitor's container.
+echo "Copying ROS log files from competitor container..."
+docker cp --follow-link ariac-competitor-${TEAM_NAME}-system:/root/.ros/log/latest $HOST_LOG_DIR/ros-competitor
+echo -e "${GREEN}OK${NOCOLOR}"
 
 ./kill_ariac_containers.bash

--- a/run_trial.bash
+++ b/run_trial.bash
@@ -35,6 +35,9 @@ fi
 
 LOG_DIR=/ariac/logs
 
+# Ensure any previous containers are killed and removed.
+./kill_ariac_containers.bash
+
 # Create the network for the containers to talk to each other.
 ./ariac-competitor/ariac_network.bash
 
@@ -58,3 +61,5 @@ docker cp --follow-link ariac-competitor-${TEAM_NAME}-system:/root/.ros/log/late
 echo -e "${GREEN}OK${NOCOLOR}"
 
 ./kill_ariac_containers.bash
+
+exit 0

--- a/run_trial.bash
+++ b/run_trial.bash
@@ -34,8 +34,8 @@ LOG_DIR=/ariac/logs
 ./ariac-competitor/ariac_network.bash
 
 # Start the competitors container and let it run in the background.
-#TODO: parameterize the container name
-./ariac-competitor/run_competitor_container.bash "/run_team_system_with_delay.bash" &
+COMPETITOR_IMAGE_NAME="ariac-competitor-${TEAM_NAME}"
+./ariac-competitor/run_competitor_container.bash ${COMPETITOR_IMAGE_NAME} "/run_team_system_with_delay.bash" &
 
 # Start the competition server. When the trial ends, the container will be killed.
 # The trial may end because of time-out, because of completion, or because the user called the

--- a/team_configs/example_team2/build_team_system.bash
+++ b/team_configs/example_team2/build_team_system.bash
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+echo "Running build_team_system.bash for example_team2"
+
+# Prepare ROS
+. /opt/ros/${ROS_DISTRO}/setup.bash
+
+# Install the necessary dependencies for getting the team's source code
+# Note: there is no need to use `sudo`.
+apt-get update
+apt-get install -y wget unzip
+
+# Create a catkin workspace
+mkdir -p ~/my_team_ws/src
+
+# Fetch the source code for our team's code
+cd ~/my_team_ws/src
+wget https://bitbucket.org/osrf/ariac_team_example/get/master.zip
+unzip master.zip
+
+cd ~/my_team_ws
+catkin_make install

--- a/team_configs/example_team2/ros_distro.txt
+++ b/team_configs/example_team2/ros_distro.txt
@@ -1,0 +1,1 @@
+kinetic

--- a/team_configs/example_team2/run_team_system.bash
+++ b/team_configs/example_team2/run_team_system.bash
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+. ~/my_team_ws/install/setup.bash
+
+# Run the example node
+echo "Launching ARIAC example nodes for example_team2"
+roslaunch ariac_team_example example_nodes.launch

--- a/team_configs/example_team2/team_config.yaml
+++ b/team_configs/example_team2/team_config.yaml
@@ -1,0 +1,33 @@
+arm:
+  type: ur10
+sensors:
+  break_beam_1:
+    type: break_beam
+    pose:
+      xyz: [1.6, 2.25, 0.91]
+      rpy: [0, 0, 'pi']
+  proximity_sensor_1:
+    type: proximity_sensor
+    pose:
+      xyz: [0.95, 2.6, 0.916]
+      rpy: [0, 0, 0]
+  logical_camera_1:
+    type: logical_camera
+    pose:
+      xyz: [-0.66, 0.22, 1.36]
+      rpy: ['pi/2', 1.32, 0]
+  logical_camera_2:
+    type: logical_camera
+    pose:
+      xyz: [0.3, 3.15, 1.5]
+      rpy: [0, 'pi/2', 0]
+  logical_camera_3:
+    type: logical_camera
+    pose:
+      xyz: [0.3, -3.15, 1.5]
+      rpy: [0, 'pi/2', 0]
+  laser_profiler_1:
+    type: laser_profiler
+    pose:
+      xyz: [1.21, 4, 1.64]
+      rpy: ['-pi', 'pi/2', 'pi/2']


### PR DESCRIPTION
1. Teams now provide a `ros_distro.txt` file with either indigo or kinetic in it to specify their distro preference.
1. ARIAC server docker images are made with the `-indigo` or `-kinetic` suffixes.
1. Teams' images are made with their team name embedded.
1. Teams' systems can be run one after an another, for all trials, using the appropriate server image given their ROS distro selection. This is done with the new `run_all_teams.bash` script, which takes no arguments.
1. If one trial fails to run, the others are still run. Console output is stored in text files for review.
