### PR TITLE
Auto end competition if team code dies

### DIFF
--- a/ariac-competitor/ariac-competitor/run_team_system_with_delay.bash
+++ b/ariac-competitor/ariac-competitor/run_team_system_with_delay.bash
@@ -11,4 +11,6 @@ sleep 20
 echo "Running team's system"
 /run_team_system.bash
 
-echo "Team's system finished running"
+echo "Team's system finished running, ending competition"
+rosservice call /ariac/end_competition
+echo "Competition ended"


### PR DESCRIPTION
Calls `/ariac/end_competition` after `run_team_system.bash` which happens if competitor code shuts down completely.