### PR TITLE
Remove prerelease bootstrap

### DIFF
--- a/ariac-competitor/ariac-competitor-base/Dockerfile_generic
+++ b/ariac-competitor/ariac-competitor-base/Dockerfile_generic
@@ -12,9 +12,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
 RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list
 
-# Bootstrap this repo with the prerelease
-RUN sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-prerelease bionic main" > /etc/apt/sources.list.d/gazebo-prerelease.list'
-
 # Install the ariac package
 RUN apt-get update && apt-get install -y \
         ros-${ROS_DISTRO}-ros-controllers \

--- a/ariac-server/ariac-server/Dockerfile_generic
+++ b/ariac-server/ariac-server/Dockerfile_generic
@@ -3,9 +3,6 @@ USER root
 
 ARG ROS_DISTRO_BUILD_TIME
 
-# Bootstrap this repo with the prerelease
-RUN sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-prerelease bionic main" > /etc/apt/sources.list.d/gazebo-prerelease.list'
-
 # Install the ariac package
 RUN apt-get update && apt-get install -y \
         ros-${ROS_DISTRO_BUILD_TIME}-ros-controllers \


### PR DESCRIPTION
Prerelease repo is no longer needed since there is a stable release