### PR TITLE
Fix: Missing Public Key and Incorrect Run Variable

### DIFF
--- a/ariac-competitor/ariac-competitor/Dockerfile
+++ b/ariac-competitor/ariac-competitor/Dockerfile
@@ -1,5 +1,6 @@
 FROM ariac/ariac3-competitor-base-melodic:latest
 
+COPY ./fast_rl_ws /fast_rl_ws
 COPY ./build_team_system.bash /
 RUN chmod 755 /build_team_system.bash
 RUN /build_team_system.bash

--- a/ariac-server/ariac-server/Dockerfile
+++ b/ariac-server/ariac-server/Dockerfile
@@ -53,8 +53,7 @@ RUN mkdir -p /tmp/ros_ws/src
 RUN /bin/bash -c "source /opt/ros/melodic/setup.bash && \
                   cd /tmp/ros_ws/src && \
                   catkin_init_workspace"
-RUN git clone \
-      https://github.com/osrf/ariac-gazebo_ros_pkgs.git /tmp/ros_ws/src/gazebo_ros_pkgs \
+RUN git clone https://github.com/osrf/ariac-gazebo_ros_pkgs.git /tmp/ros_ws/src/gazebo_ros_pkgs \
       -b ariac-network-melodic
 RUN /bin/bash -c "source /opt/ros/melodic/setup.bash && \
                   cd /tmp/ros_ws/ && \

--- a/ariac-server/ariac-server/Dockerfile
+++ b/ariac-server/ariac-server/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
 
 # setup keys and sources for official Gazebo and ROS debian packages
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys D2486D2DD83DB69272AFE98867170598AF249743 \
+ && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F42ED6FBAB17C654 \
  && echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable bionic main" > /etc/apt/sources.list.d/gazebo-latest.list \
  && apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116 \
  && echo "deb http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources.list.d/ros-latest.list
@@ -89,5 +90,7 @@ RUN wget -P /tmp/ https://bitbucket.org/osrf/gazebo_models/get/default.tar.gz \
 # setup entrypoint
 COPY ./ariac_entrypoint.sh /
 COPY ./run_ariac_task.sh /
+
+
 
 ENTRYPOINT ["/ariac_entrypoint.sh"]

--- a/ariac-server/ariac-server/Dockerfile
+++ b/ariac-server/ariac-server/Dockerfile
@@ -91,6 +91,4 @@ RUN wget -P /tmp/ https://bitbucket.org/osrf/gazebo_models/get/default.tar.gz \
 COPY ./ariac_entrypoint.sh /
 COPY ./run_ariac_task.sh /
 
-
-
 ENTRYPOINT ["/ariac_entrypoint.sh"]

--- a/ariac-server/run_container.bash
+++ b/ariac-server/run_container.bash
@@ -56,12 +56,12 @@ then
   fi
 else
   DOCKER_GPU_PARAMS=""
-  DISPLAY_PARAMS=""
+  DISPLAY_PARAMS=" -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY"
 fi
 
 DISPLAY="${DISPLAY:-:0}"
 
-docker run --rm --name ${CONTAINER} \
+docker run --rm -it --name ${CONTAINER} \
   -e XAUTHORITY=/tmp/.docker.xauth \
   -e ROS_IP=${IP} \
   -e ROS_MASTER_URI=http://${IP}:11311 \
@@ -71,6 +71,7 @@ docker run --rm --name ${CONTAINER} \
   -v "/tmp/.docker.xauth:/tmp/.docker.xauth" \
   -v /dev/log:/dev/log \
   ${DOCKER_EXTRA_ARGS} \
+  ${DISPLAY_PARAMS} \
   ${DOCKER_GPU_PARAMS} \
   ${DOCKER_DISPLAY_PARAMS} \
   ${IMAGE_NAME} \

--- a/ariac-server/run_container.bash
+++ b/ariac-server/run_container.bash
@@ -61,7 +61,7 @@ fi
 
 DISPLAY="${DISPLAY:-:0}"
 
-docker run --rm -it --name ${CONTAINER} \
+docker run --rm --name ${CONTAINER} \
   -e XAUTHORITY=/tmp/.docker.xauth \
   -e ROS_IP=${IP} \
   -e ROS_MASTER_URI=http://${IP}:11311 \
@@ -73,6 +73,6 @@ docker run --rm -it --name ${CONTAINER} \
   ${DOCKER_EXTRA_ARGS} \
   ${DISPLAY_PARAMS} \
   ${DOCKER_GPU_PARAMS} \
-  ${DISPLAY_PARAMS} \
+  ${DOCKER_DISPLAY_PARAMS} \
   ${IMAGE_NAME} \
   ${COMMAND}

--- a/ariac-server/run_container.bash
+++ b/ariac-server/run_container.bash
@@ -56,12 +56,12 @@ then
   fi
 else
   DOCKER_GPU_PARAMS=""
-  DISPLAY_PARAMS=" -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY"
+  DISPLAY_PARAMS=""
 fi
 
 DISPLAY="${DISPLAY:-:0}"
 
-docker run --rm --name ${CONTAINER} \
+docker run --rm -it --name ${CONTAINER} \
   -e XAUTHORITY=/tmp/.docker.xauth \
   -e ROS_IP=${IP} \
   -e ROS_MASTER_URI=http://${IP}:11311 \
@@ -73,6 +73,6 @@ docker run --rm --name ${CONTAINER} \
   ${DOCKER_EXTRA_ARGS} \
   ${DISPLAY_PARAMS} \
   ${DOCKER_GPU_PARAMS} \
-  ${DOCKER_DISPLAY_PARAMS} \
+  ${DISPLAY_PARAMS} \
   ${IMAGE_NAME} \
   ${COMMAND}

--- a/ariac-server/run_container.bash
+++ b/ariac-server/run_container.bash
@@ -56,12 +56,12 @@ then
   fi
 else
   DOCKER_GPU_PARAMS=""
-  DISPLAY_PARAMS=""
+  DISPLAY_PARAMS=" -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY"
 fi
 
 DISPLAY="${DISPLAY:-:0}"
 
-docker run --rm --name ${CONTAINER} \
+docker run --rm -it --name ${CONTAINER} \
   -e XAUTHORITY=/tmp/.docker.xauth \
   -e ROS_IP=${IP} \
   -e ROS_MASTER_URI=http://${IP}:11311 \

--- a/ariac-server/run_container.bash
+++ b/ariac-server/run_container.bash
@@ -56,7 +56,7 @@ then
   fi
 else
   DOCKER_GPU_PARAMS=""
-  DISPLAY_PARAMS=" -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY"
+  DISPLAY_PARAMS=""
 fi
 
 DISPLAY="${DISPLAY:-:0}"

--- a/ariac-server/run_container.bash
+++ b/ariac-server/run_container.bash
@@ -61,7 +61,7 @@ fi
 
 DISPLAY="${DISPLAY:-:0}"
 
-docker run --rm -it --name ${CONTAINER} \
+docker run --rm --name ${CONTAINER} \
   -e XAUTHORITY=/tmp/.docker.xauth \
   -e ROS_IP=${IP} \
   -e ROS_MASTER_URI=http://${IP}:11311 \


### PR DESCRIPTION
First: Fixed is related to: #32 . For me the docker file would fail to install due to a missing key.

Second: Fixed `run_container.bash`.
Define DISPLAY_PARAMS:
```bash
    DISPLAY_PARAMS=" -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY"
  else
    echo nvidia-docker-plugin not responding on http://localhost:3476/docker/cli
    echo please install nvidia-docker-plugin
    echo https://github.com/NVIDIA/nvidia-docker/wiki/Installation
    exit -1
  fi
else
  DOCKER_GPU_PARAMS=""
  DISPLAY_PARAMS=""
```
But in the run section:
```bash
docker run --rm --name ${CONTAINER} \
  -e XAUTHORITY=/tmp/.docker.xauth \
  -e ROS_IP=${IP} \
  -e ROS_MASTER_URI=http://${IP}:11311 \
  --ip ${IP} \
  --net ${NETWORK} \
  -v "/etc/localtime:/etc/localtime:ro" \
  -v "/tmp/.docker.xauth:/tmp/.docker.xauth" \
  -v /dev/log:/dev/log \
  ${DOCKER_EXTRA_ARGS} \
  ${DOCKER_GPU_PARAMS} \
  ${DOCKER_DISPLAY_PARAMS} \
  ${IMAGE_NAME} \
  ${COMMAND}
```
Where is `DISPLAY_PARAMS`? I think it was meant to be `DOCKER_DISPLAY_PARAMS`?
My solution is add `DISPLAY_PARAMS` as an arguement.
